### PR TITLE
Add SetPlayerKnows func

### DIFF
--- a/include/RE/T/TESForm.h
+++ b/include/RE/T/TESForm.h
@@ -351,6 +351,8 @@ namespace RE
 		[[nodiscard]] bool IsSoulGem() const noexcept { return Is(FormType::SoulGem); }
 		[[nodiscard]] bool IsWeapon() const noexcept { return Is(FormType::Weapon); }
 
+		void 					  SetPlayerKnows(bool a_known);
+
 		// members
 		TESFileContainer                                sourceFiles;      // 08
 		std::uint32_t                                   formFlags;        // 10

--- a/src/RE/T/TESForm.cpp
+++ b/src/RE/T/TESForm.cpp
@@ -174,4 +174,11 @@ namespace RE
 			return false;
 		}
 	}
+
+	void TESForm::SetPlayerKnows(bool a_known) 
+	{
+		using func_t = decltype(&TESForm::SetPlayerKnows);
+    	REL::Relocation<func_t> func{ RELOCATION_ID(14482, 14639) };
+    	return func(this, a_known);
+	}
 }


### PR DESCRIPTION
Adds native implementation of SetPlayerKnows, which is properly handled by save data unlike directly setting the flag.